### PR TITLE
Fix mod name not matching url:

### DIFF
--- a/app/go.mod
+++ b/app/go.mod
@@ -1,4 +1,4 @@
-module github.com/omaressameldin/lazy-panda-utils
+module github.com/omaressameldin/lazy-panda-utils/app
 
 go 1.12
 

--- a/app/go.sum
+++ b/app/go.sum
@@ -22,6 +22,7 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
+github.com/omaressameldin/lazy-panda-utils v0.0.0-20190526002045-b81327c7d9f7 h1:rU0FkLtvPvUbg3XguN3ooZ7NKsFUknZAoWcfnaTS7bI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=

--- a/app/pkg/firebase/adapter.go
+++ b/app/pkg/firebase/adapter.go
@@ -3,7 +3,7 @@ package firebase
 import (
 	"fmt"
 
-	"github.com/omaressameldin/lazy-panda-utils/pkg/database"
+	"github.com/omaressameldin/lazy-panda-utils/app/pkg/database"
 	"golang.org/x/net/context"
 	"google.golang.org/api/iterator"
 )

--- a/app/pkg/firebase/utils.go
+++ b/app/pkg/firebase/utils.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/firestore"
-	"github.com/omaressameldin/lazy-panda-utils/pkg/database"
+	"github.com/omaressameldin/lazy-panda-utils/app/pkg/database"
 )
 
 func createError(err error) error {


### PR DESCRIPTION
###### **please follow the guidlines mentioned below and  fill all the sections for a smoother PR 🤗**

##### Make sure **if needed** that you:
* [x] wrote a clear description of the pr ( see below :arrow_down: )
* [x] followed our current commits and branching scheme ( please check [contributing.md](../contributing.md))
* [x] rebased your code on top of master
* [ ] wrote tests for your introduced code
* [ ] updated any existing tests to work with your new code


### Description:
#### 📰 please write a clear description of what this PR is about
- Because module name in `go.mod` file differs from the repo url, I was not able to import that package in other places. Therefore, changing the mod name should fix this.

### Changes
##### :octocat:  Git  Related
- change module name in `go.mod` to match url
- update all imports in all files to match new module name

### Steps to test
- Run `docker-compose up --build` to test

### 🙄 is there anything controversial about your code ?
No :+1: 